### PR TITLE
Implement debug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //! Code sample lightly edited from src/bin.rs: 
 //!
 //! ```
+//! use std::error::Error;
+//! let file_name = "foo.jpg";
 //! match rexif::parse_file(&file_name) {
 //!	Ok(exif) => {
 //!		println!("{} {} exif entries: {}", file_name,
@@ -29,7 +31,7 @@
 //!	},
 //!	Err(e) => {
 //!		print!("Error in {}: {} {}", &file_name,
-//!			Error::description(&e), e.extra).unwrap();
+//!			Error::description(&e), e.extra)
 //!	}
 //! }
 //! ```

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fmt::Display;
 
 /// Encapsulation of the TIFF type that represents a signed rational number
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct IRational {
 	pub numerator: i32,
 	pub denominator: i32,
@@ -22,7 +22,7 @@ impl Display for IRational {
 	}
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 /// Encapsulation of the TIFF type that represents an unsigned rational number
 pub struct URational {
 	pub numerator: u32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@ use super::rational::*;
 use std::result::Result;
 
 /// Top-level structure that contains all parsed metadata inside an image
+#[derive(Debug)]
 pub struct ExifData {
 	/// MIME type of the parsed image. It may be "image/jpeg", "image/tiff", or empty if unrecognized.
 	pub mime: String,
@@ -33,7 +34,7 @@ pub struct ExifError {
 }
 
 /// Structure that represents a parsed IFD entry of a TIFF image
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IfdEntry {
 	/// Namespace of the entry. Standard is a tag found in normal TIFF IFD structure,
 	/// other namespaces are entries found e.g. within MarkerNote blobs that are
@@ -65,7 +66,7 @@ pub struct IfdEntry {
 /// Enumeration that represent EXIF tag namespaces. Namespaces exist to
 /// accomodate future parsing of the manufacturer-specific tags embedded within
 /// the MarkerNote tag.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Namespace {
 	Standard = 0x0000,
 	Nikon = 0x0001,
@@ -82,7 +83,7 @@ pub enum Namespace {
 /// the `Namespace` enumeration. The namespace is 0 for standard Exif tags.
 /// The non-standard namespaces exist to accomodate future parsing of the
 /// MarkerNote tag, that contains embedded manufacturer-specific tags.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ExifTag {
 	/// Tag not recognized are partially parsed. The client may still try to interpret
 	/// the tag by reading into the IfdFormat structure.
@@ -194,7 +195,7 @@ pub enum ExifTag {
 ///
 /// Any enumeration item can be cast to u16 to get the low-level format code
 /// as defined by the TIFF format.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum IfdFormat {
 	Unknown = 0,
 	U8 = 1,
@@ -212,7 +213,7 @@ pub enum IfdFormat {
 }
 
 /// Structure that represents a parsed EXIF tag.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ExifEntry {
 	/// Namespace of the tag. If Standard (0x0000), it is an EXIF tag defined in the
 	/// official standard. Other namespaces accomodate manufacturer-specific tags that
@@ -253,7 +254,7 @@ pub struct ExifEntry {
 /// Tag value enumeration. It works as a variant type. Each value is
 /// actually a vector because many EXIF tags are collections of values.
 /// Exif tags with single values are represented as single-item vectors.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum TagValue {
 	/// Array of unsigned byte integers
 	U8(Vec<u8>),


### PR DESCRIPTION
Having the debug trait implemented on the various exif data types would make exploratory development of code using the exif crate a lot easier.  And it is simple to derive the trait.
