### PR TITLE
Avoid some duplicate data representation in ExifEntry

### DIFF
--- a/src/exif.rs
+++ b/src/exif.rs
@@ -5,7 +5,7 @@ use super::exifreadable::*;
 /// is used by the main body of the parser to sanity-check the tags found in image
 /// and make sure that EXIF tags have the right data types
 pub fn tag_to_exif(f: u16) -> (ExifTag, &'static str, IfdFormat, i32, i32,
-						fn(&TagValue, s: &String) -> String)
+					           fn(&TagValue) -> String)
 {
 	match f {
 

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -4,397 +4,397 @@ use super::exifreadable::*;
 /// Convert a numeric tag into ExifTag enumeration, and yields information about the tag. This information
 /// is used by the main body of the parser to sanity-check the tags found in image
 /// and make sure that EXIF tags have the right data types
-pub fn tag_to_exif(f: u16) -> (ExifTag, &'static str, &'static str, IfdFormat, i32, i32,
+pub fn tag_to_exif(f: u16) -> (ExifTag, &'static str, IfdFormat, i32, i32,
 						fn(&TagValue, s: &String) -> String)
 {
 	match f {
 
 	0x010e =>
-	(ExifTag::ImageDescription, "Image Description", "none", IfdFormat::Ascii,
+	(ExifTag::ImageDescription, "none", IfdFormat::Ascii,
 	-1i32, -1i32, strpass),
 
 	0x010f =>
-	(ExifTag::Make, "Manufacturer", "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
+	(ExifTag::Make, "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x013c =>
-	(ExifTag::HostComputer, "Host computer", "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
+	(ExifTag::HostComputer, "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x0110 =>
-	(ExifTag::Model, "Model", "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
+	(ExifTag::Model, "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x0112 =>
-	(ExifTag::Orientation, "Orientation", "none", IfdFormat::U16, 1, 1, orientation),
+	(ExifTag::Orientation, "none", IfdFormat::U16, 1, 1, orientation),
 
 	0x011a =>
-	(ExifTag::XResolution, "X Resolution", "pixels per res unit",
+	(ExifTag::XResolution, "pixels per res unit",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0x011b =>
-	(ExifTag::YResolution, "Y Resolution", "pixels per res unit",
+	(ExifTag::YResolution, "pixels per res unit",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0x0128 =>
-	(ExifTag::ResolutionUnit, "Resolution Unit", "none", IfdFormat::U16, 1, 1, resolution_unit),
+	(ExifTag::ResolutionUnit, "none", IfdFormat::U16, 1, 1, resolution_unit),
 
 	0x0131 =>
-	(ExifTag::Software, "Software", "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
+	(ExifTag::Software, "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x0132 =>
-	(ExifTag::DateTime, "Image date", "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
+	(ExifTag::DateTime, "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x013e =>
-	(ExifTag::WhitePoint, "White Point", "CIE 1931 coordinates",
+	(ExifTag::WhitePoint, "CIE 1931 coordinates",
 	IfdFormat::URational, 2, 2, rational_values),
 
 	0x013f =>
-	(ExifTag::PrimaryChromaticities, "Primary Chromaticities", "CIE 1931 coordinates",
+	(ExifTag::PrimaryChromaticities, "CIE 1931 coordinates",
 	IfdFormat::URational, 6, 6, rational_values),
 
 	0x0211 =>
-	(ExifTag::YCbCrCoefficients, "YCbCr Coefficients", "none",
+	(ExifTag::YCbCrCoefficients, "none",
 	IfdFormat::URational, 3, 3, rational_values),
 
 	0x0214 =>
-	(ExifTag::ReferenceBlackWhite, "Reference Black/White", "RGB or YCbCr",
+	(ExifTag::ReferenceBlackWhite, "RGB or YCbCr",
 	IfdFormat::URational, 6, 6, rational_values),
 
 	0x8298 =>
-	(ExifTag::Copyright, "Copyright", "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
+	(ExifTag::Copyright, "none", IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x8769 =>
-	(ExifTag::ExifOffset, "This image has an Exif SubIFD", "byte offset",
+	(ExifTag::ExifOffset, "byte offset",
 	IfdFormat::U32, 1, 1, strpass),
 
 	0x8825 =>
-	(ExifTag::GPSOffset, "This image has a GPS SubIFD", "byte offset",
+	(ExifTag::GPSOffset, "byte offset",
 	IfdFormat::U32, 1, 1, strpass),
 
 	0x829a =>
-	(ExifTag::ExposureTime, "Exposure time", "s",
+	(ExifTag::ExposureTime, "s",
 	IfdFormat::URational, 1, 1, exposure_time),
 
 	0x829d =>
-	(ExifTag::FNumber, "Aperture", "f-number",
+	(ExifTag::FNumber, "f-number",
 	IfdFormat::URational, 1, 1, f_number),
 
 	0x8822 =>
-	(ExifTag::ExposureProgram, "Exposure program", "none",
+	(ExifTag::ExposureProgram, "none",
 	IfdFormat::U16, 1, 1, exposure_program),
 
 	0x8824 =>
-	(ExifTag::SpectralSensitivity, "Spectral sensitivity", "ASTM string",
+	(ExifTag::SpectralSensitivity, "ASTM string",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x8827 =>
-	(ExifTag::ISOSpeedRatings, "ISO speed ratings", "ISO",
+	(ExifTag::ISOSpeedRatings, "ISO",
 	IfdFormat::U16, 1, 3, iso_speeds),
 
 	0x8828 =>
-	(ExifTag::OECF, "OECF", "none",
+	(ExifTag::OECF, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_blob),
 
 	0x9000 =>
-	(ExifTag::ExifVersion, "Exif version", "none",
+	(ExifTag::ExifVersion, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_ascii),
 
 	0x9003 =>
-	(ExifTag::DateTimeOriginal, "Date of original image", "none",
+	(ExifTag::DateTimeOriginal, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x9004 =>
-	(ExifTag::DateTimeDigitized, "Date of image digitalization", "none",
+	(ExifTag::DateTimeDigitized, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x9201 =>
-	(ExifTag::ShutterSpeedValue, "Shutter speed", "APEX",
+	(ExifTag::ShutterSpeedValue, "APEX",
 	IfdFormat::IRational, 1, 1, apex_tv),
 	
 	0x9202 =>
-	(ExifTag::ApertureValue, "Aperture value", "APEX",
+	(ExifTag::ApertureValue, "APEX",
 	IfdFormat::URational, 1, 1, apex_av),
 
 	0x9203 =>
-	(ExifTag::BrightnessValue, "Brightness value", "APEX",
+	(ExifTag::BrightnessValue, "APEX",
 	IfdFormat::IRational, 1, 1, apex_brightness),
 
 	0x9204 =>
-	(ExifTag::ExposureBiasValue, "Exposure bias value", "APEX",
+	(ExifTag::ExposureBiasValue, "APEX",
 	IfdFormat::IRational, 1, 1, apex_ev),
 
 	0x9205 =>
-	(ExifTag::MaxApertureValue, "Maximum aperture value",
-	"APEX", IfdFormat::URational, 1, 1, apex_av),
+	(ExifTag::MaxApertureValue,
+        "APEX", IfdFormat::URational, 1, 1, apex_av),
 
 	0x9206 =>
-	(ExifTag::SubjectDistance, "Subject distance", "m",
+	(ExifTag::SubjectDistance, "m",
 	IfdFormat::URational, 1, 1, meters),
 
 	0x9207 =>
-	(ExifTag::MeteringMode, "Meteting mode", "none",
+	(ExifTag::MeteringMode, "none",
 	IfdFormat::U16, 1, 1, metering_mode),
 
 	0x9208 =>
-	(ExifTag::LightSource, "Light source", "none",
+	(ExifTag::LightSource, "none",
 	IfdFormat::U16, 1, 1, light_source),
 
-	0x9209 => (ExifTag::Flash, "Flash", "none",
+	0x9209 => (ExifTag::Flash, "none",
 	IfdFormat::U16, 1, 2, flash),
 
 	0x920a =>
-	(ExifTag::FocalLength, "Focal length", "mm",
+	(ExifTag::FocalLength, "mm",
 	IfdFormat::URational, 1, 1, focal_length),
 
 	0x9214 =>
-	(ExifTag::SubjectArea, "Subject area", "px",
+	(ExifTag::SubjectArea, "px",
 	IfdFormat::U16, 2, 4, subject_area),
 
 	0x927c =>
-	(ExifTag::MakerNote, "Maker note", "none",
+	(ExifTag::MakerNote, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_blob),
 
 	0x9286 =>
-	(ExifTag::UserComment, "User comment", "none",
+	(ExifTag::UserComment, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_encoded_string),
 
 	0xa000 =>
-	(ExifTag::FlashPixVersion, "Flashpix version", "none",
+	(ExifTag::FlashPixVersion, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_ascii),
 
 	0xa001 =>
-	(ExifTag::ColorSpace, "Color space", "none",
+	(ExifTag::ColorSpace, "none",
 	IfdFormat::U16, 1, 1, color_space),
 
 	0xa004 =>
-	(ExifTag::RelatedSoundFile, "Related sound file", "none",
+	(ExifTag::RelatedSoundFile, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
-	0xa20b => (ExifTag::FlashEnergy, "Flash energy", "BCPS",
+	0xa20b => (ExifTag::FlashEnergy, "BCPS",
 	IfdFormat::URational, 1, 1, flash_energy),
 
 	0xa20e =>
-	(ExifTag::FocalPlaneXResolution, "Focal plane X resolution", "@FocalPlaneResolutionUnit",
+	(ExifTag::FocalPlaneXResolution, "@FocalPlaneResolutionUnit",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0xa20f =>
-	(ExifTag::FocalPlaneYResolution, "Focal plane Y resolution", "@FocalPlaneResolutionUnit",
+	(ExifTag::FocalPlaneYResolution, "@FocalPlaneResolutionUnit",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0xa210 =>
-	(ExifTag::FocalPlaneResolutionUnit, "Focal plane resolution unit", "none",
+	(ExifTag::FocalPlaneResolutionUnit, "none",
 	IfdFormat::U16, 1, 1, resolution_unit),
 
 	0xa214 =>
-	(ExifTag::SubjectLocation, "Subject location", "X,Y",
+	(ExifTag::SubjectLocation, "X,Y",
 	IfdFormat::U16, 2, 2, subject_location),
 
 	// TODO check if rational as decimal value is the best for this one
 	0xa215 =>
-	(ExifTag::ExposureIndex, "Exposure index", "EI",
+	(ExifTag::ExposureIndex, "EI",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0xa217 =>
-	(ExifTag::SensingMethod, "Sensing method", "none",
+	(ExifTag::SensingMethod, "none",
 	IfdFormat::U16, 1, 1, sensing_method),
 
 	0xa300 =>
-	(ExifTag::FileSource, "File source", "none",
+	(ExifTag::FileSource, "none",
 	IfdFormat::Undefined, 1, 1, file_source),
 
 	0xa301 =>
-	(ExifTag::SceneType, "Scene type", "none",
+	(ExifTag::SceneType, "none",
 	IfdFormat::Undefined, 1, 1, scene_type),
 
 	0xa302 =>
-	(ExifTag::CFAPattern, "CFA Pattern", "none",
+	(ExifTag::CFAPattern, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_u8),
 
 	0xa401 =>
-	(ExifTag::CustomRendered, "Custom rendered", "none",
+	(ExifTag::CustomRendered, "none",
 	IfdFormat::U16, 1, 1, custom_rendered),
 
 	0xa402 =>
-	(ExifTag::ExposureMode, "Exposure mode", "none",
+	(ExifTag::ExposureMode, "none",
 	IfdFormat::U16, 1, 1, exposure_mode),
 
 	0xa403 =>
-	(ExifTag::WhiteBalanceMode, "White balance mode", "none",
+	(ExifTag::WhiteBalanceMode, "none",
 	IfdFormat::U16, 1, 1, white_balance_mode),
 
 	0xa404 =>
-	(ExifTag::DigitalZoomRatio, "Digital zoom ratio", "none",
+	(ExifTag::DigitalZoomRatio, "none",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0xa405 =>
-	(ExifTag::FocalLengthIn35mmFilm, "Equivalent focal length in 35mm", "mm",
+	(ExifTag::FocalLengthIn35mmFilm, "mm",
 	IfdFormat::U16, 1, 1, focal_length_35),
 
 	0xa406 =>
-	(ExifTag::SceneCaptureType, "Scene capture type", "none",
+	(ExifTag::SceneCaptureType, "none",
 	IfdFormat::U16, 1, 1, scene_capture_type),
 
 	0xa407 =>
-	(ExifTag::GainControl, "Gain control", "none",
+	(ExifTag::GainControl, "none",
 	IfdFormat::U16, 1, 1, gain_control),
 
 	0xa408 =>
-	(ExifTag::Contrast, "Contrast", "none",
+	(ExifTag::Contrast, "none",
 	IfdFormat::U16, 1, 1, contrast),
 
 	0xa409 =>
-	(ExifTag::Saturation, "Saturation", "none",
+	(ExifTag::Saturation, "none",
 	IfdFormat::U16, 1, 1, saturation),
 
 	0xa40a =>
-	(ExifTag::Sharpness, "Sharpness", "none",
+	(ExifTag::Sharpness, "none",
 	IfdFormat::U16, 1, 1, sharpness),
 
 	0xa432 =>
-	(ExifTag::LensSpecification, "Lens specification", "none",
+	(ExifTag::LensSpecification, "none",
 	IfdFormat::URational, 4, 4, lens_spec),
 
 	0xa433 =>
-	(ExifTag::LensMake, "Lens manufacturer", "none",
+	(ExifTag::LensMake, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0xa434 =>
-	(ExifTag::LensModel, "Lens model", "none",
+	(ExifTag::LensModel, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	// collaborate if you have any idea how to interpret this
 	0xa40b =>
-	(ExifTag::DeviceSettingDescription, "Device setting description", "none",
+	(ExifTag::DeviceSettingDescription, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_blob),
 
 	0xa40c =>
-	(ExifTag::SubjectDistanceRange, "Subject distance range", "none",
+	(ExifTag::SubjectDistanceRange, "none",
 	IfdFormat::U16, 1, 1, subject_distance_range),
 
 	0xa420 =>
-	(ExifTag::ImageUniqueID, "Image unique ID", "none",
+	(ExifTag::ImageUniqueID, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 		
 	0x0 =>
-	(ExifTag::GPSVersionID, "GPS version ID", "none",
+	(ExifTag::GPSVersionID, "none",
 	IfdFormat::U8, 4, 4, strpass),
 
 	0x1 =>
-	(ExifTag::GPSLatitudeRef, "GPS latitude ref", "none",
+	(ExifTag::GPSLatitudeRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x2 =>
-	(ExifTag::GPSLatitude, "GPS latitude", "D/M/S",
+	(ExifTag::GPSLatitude, "D/M/S",
 	IfdFormat::URational, 3, 3, dms),
 
 	0x3 =>
-	(ExifTag::GPSLongitudeRef, "GPS longitude ref", "none",
+	(ExifTag::GPSLongitudeRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x4 =>
-	(ExifTag::GPSLongitude, "GPS longitude", "D/M/S",
+	(ExifTag::GPSLongitude, "D/M/S",
 	IfdFormat::URational, 3, 3, dms),
 
 	0x5 =>
-	(ExifTag::GPSAltitudeRef, "GPS altitude ref", "none",
+	(ExifTag::GPSAltitudeRef, "none",
 	IfdFormat::U8, 1, 1, gps_alt_ref),
 
 	0x6 =>
-	(ExifTag::GPSAltitude, "GPS altitude", "m",
+	(ExifTag::GPSAltitude, "m",
 	IfdFormat::URational, 1, 1, meters),
 
 	0x7 =>
-	(ExifTag::GPSTimeStamp, "GPS timestamp", "UTC time",
+	(ExifTag::GPSTimeStamp, "UTC time",
 	IfdFormat::URational, 3, 3, gpstimestamp),
 
-	0x8 => (ExifTag::GPSSatellites, "GPS satellites", "none",
+	0x8 => (ExifTag::GPSSatellites, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
-	0x9 => (ExifTag::GPSStatus, "GPS status", "none",
+	0x9 => (ExifTag::GPSStatus, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsstatus),
 
-	0xa => (ExifTag::GPSMeasureMode, "GPS measure mode", "none",
+	0xa => (ExifTag::GPSMeasureMode, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsmeasuremode),
 
 	0xb =>
-	(ExifTag::GPSDOP, "GPS Data Degree of Precision (DOP)", "none",
+	(ExifTag::GPSDOP, "none",
 	IfdFormat::URational, 1, 1, rational_value),
 
 	0xc =>
-	(ExifTag::GPSSpeedRef, "GPS speed ref", "none",
+	(ExifTag::GPSSpeedRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsspeedref),
 
 	0xd =>
-	(ExifTag::GPSSpeed, "GPS speed", "@GPSSpeedRef",
+	(ExifTag::GPSSpeed, "@GPSSpeedRef",
 	IfdFormat::URational, 1, 1, gpsspeed),
 
 	0xe =>
-	(ExifTag::GPSTrackRef, "GPS track ref", "none",
+	(ExifTag::GPSTrackRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsbearingref),
 
 	0xf =>
-	(ExifTag::GPSTrack, "GPS track", "deg",
+	(ExifTag::GPSTrack, "deg",
 	IfdFormat::URational, 1, 1, gpsbearing),
 
 	0x10 =>
-	(ExifTag::GPSImgDirectionRef, "GPS image direction ref", "none",
+	(ExifTag::GPSImgDirectionRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsbearingref),
 
 	0x11 =>
-	(ExifTag::GPSImgDirection, "GPS image direction", "deg",
+	(ExifTag::GPSImgDirection, "deg",
 	IfdFormat::URational, 1, 1, gpsbearing),
 
 	0x12 =>
-	(ExifTag::GPSMapDatum, "GPS map datum", "none",
+	(ExifTag::GPSMapDatum, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x13 =>
-	(ExifTag::GPSDestLatitudeRef, "GPS destination latitude ref", "none",
+	(ExifTag::GPSDestLatitudeRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x14 =>
-	(ExifTag::GPSDestLatitude, "GPS destination latitude", "D/M/S",
+	(ExifTag::GPSDestLatitude, "D/M/S",
 	IfdFormat::URational, 3, 3, dms),
 
 	0x15 =>
-	(ExifTag::GPSDestLongitudeRef, "GPS destination longitude ref", "none",
+	(ExifTag::GPSDestLongitudeRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x16 =>
-	(ExifTag::GPSDestLongitude, "GPS destination longitude", "D/M/S",
+	(ExifTag::GPSDestLongitude, "D/M/S",
 	IfdFormat::URational, 3, 3, dms),
 
 	0x17 =>
-	(ExifTag::GPSDestBearingRef, "GPS destination bearing ref", "none",
+	(ExifTag::GPSDestBearingRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsbearingref),
 
 	0x18 =>
-	(ExifTag::GPSDestBearing, "GPS destination bearing", "deg",
+	(ExifTag::GPSDestBearing, "deg",
 	IfdFormat::URational, 1, 1, gpsbearing),
 
 	0x19 =>
-	(ExifTag::GPSDestDistanceRef, "GPS destination distance ref", "none",
+	(ExifTag::GPSDestDistanceRef, "none",
 	IfdFormat::Ascii, -1i32, -1i32, gpsdestdistanceref),
 
 	0x1a =>
-	(ExifTag::GPSDestDistance, "GPS destination distance", "@GPSDestDistanceRef",
+	(ExifTag::GPSDestDistance, "@GPSDestDistanceRef",
 	IfdFormat::URational, 1, 1, gpsdestdistance),
 
 	0x1b =>
-	(ExifTag::GPSProcessingMethod, "GPS processing method", "none",
+	(ExifTag::GPSProcessingMethod, "none",
 	IfdFormat::Undefined, -1i32, -1i32, undefined_as_encoded_string),
 
-	0x1c => (ExifTag::GPSAreaInformation, "GPS area information",
+	0x1c => (ExifTag::GPSAreaInformation,
 	"none", IfdFormat::Undefined, -1i32, -1i32, undefined_as_encoded_string),
 
 	0x1d =>
-	(ExifTag::GPSDateStamp, "GPS date stamp", "none",
+	(ExifTag::GPSDateStamp, "none",
 	IfdFormat::Ascii, -1i32, -1i32, strpass),
 
 	0x1e =>
-	(ExifTag::GPSDifferential, "GPS differential", "none",
+	(ExifTag::GPSDifferential, "none",
 	IfdFormat::U16, 1, 1, gpsdiff),
 
 	_ =>
-	(ExifTag::UnknownToMe, "Unknown to this library, or manufacturer-specific", "Unknown unit",
+	(ExifTag::UnknownToMe, "Unknown unit",
 	IfdFormat::Unknown, -1i32, -1i32, nop)
 
 	}

--- a/src/exifreadable.rs
+++ b/src/exifreadable.rs
@@ -6,19 +6,19 @@ static INV: &'static str = "Invalid data for this tag";
 
 /// No-op for readable value tag function. Should not be used by any EXIF tag descriptor,
 /// except for the catch-all match that handles unknown tags
-pub fn nop(_: &TagValue, s: &String) -> String
+pub fn nop(e: &TagValue) -> String
 {
-	return s.clone();
+	format!("{}", e)
 }
 
 /// No-op for readable value tag function. Used for ASCII string tags, or when the
 /// default readable representation of value is pretty enough.
-pub fn strpass(_: &TagValue, s: &String) -> String
+pub fn strpass(e: &TagValue) -> String
 {
-	return s.clone();
+	format!("{}", e)
 }
 
-pub fn orientation(e: &TagValue, _: &String) -> String
+pub fn orientation(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -38,7 +38,7 @@ pub fn orientation(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn rational_value(e: &TagValue, _: &String) -> String
+pub fn rational_value(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -53,7 +53,7 @@ pub fn rational_value(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn rational_values(e: &TagValue, _: &String) -> String
+pub fn rational_values(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -66,7 +66,7 @@ pub fn rational_values(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn resolution_unit(e: &TagValue, _: &String) -> String
+pub fn resolution_unit(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -84,7 +84,7 @@ pub fn resolution_unit(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn exposure_time(e: &TagValue, _: &String) -> String
+pub fn exposure_time(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -106,7 +106,7 @@ pub fn exposure_time(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn f_number(e: &TagValue, _: &String) -> String
+pub fn f_number(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -118,7 +118,7 @@ pub fn f_number(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn exposure_program(e: &TagValue, _: &String) -> String
+pub fn exposure_program(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -141,7 +141,7 @@ pub fn exposure_program(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn focal_length(e: &TagValue, _: &String) -> String
+pub fn focal_length(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -153,7 +153,7 @@ pub fn focal_length(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn focal_length_35(e: &TagValue, _: &String) -> String
+pub fn focal_length_35(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -165,7 +165,7 @@ pub fn focal_length_35(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn meters(e: &TagValue, _: &String) -> String
+pub fn meters(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -177,7 +177,7 @@ pub fn meters(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn iso_speeds(e: &TagValue, _: &String) -> String
+pub fn iso_speeds(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::U16(ref v) => {
@@ -195,7 +195,7 @@ pub fn iso_speeds(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn dms(e: &TagValue, _: &String) -> String
+pub fn dms(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::URational(ref v) => {
@@ -217,7 +217,7 @@ pub fn dms(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gps_alt_ref(e: &TagValue, _: &String) -> String
+pub fn gps_alt_ref(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U8(ref v) => {
@@ -234,7 +234,7 @@ pub fn gps_alt_ref(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsdestdistanceref(e: &TagValue, _: &String) -> String
+pub fn gpsdestdistanceref(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Ascii(ref v) => {
@@ -254,7 +254,7 @@ pub fn gpsdestdistanceref(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsdestdistance(e: &TagValue, _: &String) -> String
+pub fn gpsdestdistance(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -266,7 +266,7 @@ pub fn gpsdestdistance(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsspeedref(e: &TagValue, _: &String) -> String
+pub fn gpsspeedref(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Ascii(ref v) => {
@@ -286,7 +286,7 @@ pub fn gpsspeedref(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsspeed(e: &TagValue, _: &String) -> String
+pub fn gpsspeed(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -298,7 +298,7 @@ pub fn gpsspeed(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsbearingref(e: &TagValue, _: &String) -> String
+pub fn gpsbearingref(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Ascii(ref v) => {
@@ -316,7 +316,7 @@ pub fn gpsbearingref(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsbearing(e: &TagValue, _: &String) -> String
+pub fn gpsbearing(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::URational(ref v) => {
@@ -328,7 +328,7 @@ pub fn gpsbearing(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpstimestamp(e: &TagValue, _: &String) -> String
+pub fn gpstimestamp(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::URational(ref v) => {
@@ -343,7 +343,7 @@ pub fn gpstimestamp(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsdiff(e: &TagValue, _: &String) -> String
+pub fn gpsdiff(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -360,7 +360,7 @@ pub fn gpsdiff(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsstatus(e: &TagValue, _: &String) -> String
+pub fn gpsstatus(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Ascii(ref v) => {
@@ -378,7 +378,7 @@ pub fn gpsstatus(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gpsmeasuremode(e: &TagValue, _: &String) -> String
+pub fn gpsmeasuremode(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Ascii(ref v) => {
@@ -399,7 +399,7 @@ pub fn gpsmeasuremode(e: &TagValue, _: &String) -> String
 /// Interprets an Undefined tag as ASCII, when the contents are guaranteed
 /// by EXIF standard to be ASCII-compatible. This function accepts UTF-8
 /// strings, should they be accepted by EXIF standard in the future.
-pub fn undefined_as_ascii(e: &TagValue, _: &String) -> String
+pub fn undefined_as_ascii(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Undefined(ref v, _) => {
@@ -413,7 +413,7 @@ pub fn undefined_as_ascii(e: &TagValue, _: &String) -> String
 
 /// Outputs an Undefined tag as an array of bytes. Appropriate for tags
 /// that are opaque and small-sized
-pub fn undefined_as_u8(e: &TagValue, _: &String) -> String
+pub fn undefined_as_u8(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Undefined(ref v, _) => {
@@ -428,7 +428,7 @@ pub fn undefined_as_u8(e: &TagValue, _: &String) -> String
 /// Tries to parse an Undefined tag as containing a string. For some tags,
 /// the string encoding /// format can be discovered by looking into the first
 /// 8 bytes.
-pub fn undefined_as_encoded_string(e: &TagValue, _: &String) -> String
+pub fn undefined_as_encoded_string(e: &TagValue) -> String
 {
 	// "ASCII\0\0\0"
 	static ASC: [u8; 8] = [0x41, 0x53, 0x43, 0x49, 0x49, 0, 0, 0];
@@ -463,7 +463,7 @@ pub fn undefined_as_encoded_string(e: &TagValue, _: &String) -> String
 }
 
 /// Prints an opaque and long Undefined tag simply as as "blob", noting its length
-pub fn undefined_as_blob(e: &TagValue, _: &String) -> String
+pub fn undefined_as_blob(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Undefined(ref v, _) => {
@@ -475,7 +475,7 @@ pub fn undefined_as_blob(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn apex_tv(e: &TagValue, _: &String) -> String
+pub fn apex_tv(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::IRational(ref v) => {
@@ -485,7 +485,7 @@ pub fn apex_tv(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn apex_av(e: &TagValue, _: &String) -> String
+pub fn apex_av(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::URational(ref v) => {
@@ -495,7 +495,7 @@ pub fn apex_av(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn apex_brightness(e: &TagValue, _: &String) -> String
+pub fn apex_brightness(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::IRational(ref v) => {
@@ -510,7 +510,7 @@ pub fn apex_brightness(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn apex_ev(e: &TagValue, _: &String) -> String
+pub fn apex_ev(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::IRational(ref v) => {
@@ -520,7 +520,7 @@ pub fn apex_ev(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn file_source(e: &TagValue, _: &String) -> String
+pub fn file_source(e: &TagValue) -> String
 {
 	let s = match e {
 	&TagValue::Undefined(ref v, _) => {
@@ -536,7 +536,7 @@ pub fn file_source(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn flash_energy(e: &TagValue, _: &String) -> String
+pub fn flash_energy(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::URational(ref v) => {
@@ -546,7 +546,7 @@ pub fn flash_energy(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn metering_mode(e: &TagValue, _: &String) -> String
+pub fn metering_mode(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -569,7 +569,7 @@ pub fn metering_mode(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn light_source(e: &TagValue, _: &String) -> String
+pub fn light_source(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -605,7 +605,7 @@ pub fn light_source(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn color_space(e: &TagValue, _: &String) -> String
+pub fn color_space(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -622,7 +622,7 @@ pub fn color_space(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn flash(e: &TagValue, _: &String) -> String
+pub fn flash(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::U16(ref v) => {
@@ -669,7 +669,7 @@ pub fn flash(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn subject_area(e: &TagValue, _: &String) -> String
+pub fn subject_area(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::U16(ref v) => {
@@ -684,7 +684,7 @@ pub fn subject_area(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn subject_location(e: &TagValue, _: &String) -> String
+pub fn subject_location(e: &TagValue) -> String
 {
 	match e {
 		&TagValue::U16(ref v) => {
@@ -694,7 +694,7 @@ pub fn subject_location(e: &TagValue, _: &String) -> String
 	}
 }
 
-pub fn sharpness(e: &TagValue, _: &String) -> String
+pub fn sharpness(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -712,7 +712,7 @@ pub fn sharpness(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn saturation(e: &TagValue, _: &String) -> String
+pub fn saturation(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -730,7 +730,7 @@ pub fn saturation(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn contrast(e: &TagValue, _: &String) -> String
+pub fn contrast(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -748,7 +748,7 @@ pub fn contrast(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn gain_control(e: &TagValue, _: &String) -> String
+pub fn gain_control(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -768,7 +768,7 @@ pub fn gain_control(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn exposure_mode(e: &TagValue, _: &String) -> String
+pub fn exposure_mode(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -786,7 +786,7 @@ pub fn exposure_mode(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn scene_capture_type(e: &TagValue, _: &String) -> String
+pub fn scene_capture_type(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -805,7 +805,7 @@ pub fn scene_capture_type(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn scene_type(e: &TagValue, _: &String) -> String
+pub fn scene_type(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::Undefined(ref v, _) => {
@@ -821,7 +821,7 @@ pub fn scene_type(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn white_balance_mode(e: &TagValue, _: &String) -> String
+pub fn white_balance_mode(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -838,7 +838,7 @@ pub fn white_balance_mode(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn sensing_method(e: &TagValue, _: &String) -> String
+pub fn sensing_method(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -860,7 +860,7 @@ pub fn sensing_method(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn custom_rendered(e: &TagValue, _: &String) -> String
+pub fn custom_rendered(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -877,7 +877,7 @@ pub fn custom_rendered(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn subject_distance_range(e: &TagValue, _: &String) -> String
+pub fn subject_distance_range(e: &TagValue) -> String
 {
 	let s = match e {
 		&TagValue::U16(ref v) => {
@@ -896,7 +896,7 @@ pub fn subject_distance_range(e: &TagValue, _: &String) -> String
 	return s.to_string();
 }
 
-pub fn lens_spec(e: &TagValue, _: &String) -> String
+pub fn lens_spec(e: &TagValue) -> String
 {
 	match e {
 	&TagValue::URational(ref v) => {

--- a/src/ifdformat.rs
+++ b/src/ifdformat.rs
@@ -25,8 +25,8 @@ pub fn numarray_to_string<T: Display>(numbers: &Vec<T>) -> String
 	return s;
 }
 
-/// Convert a IfdEntry into a tuple of TagValue and a crude string representation of tag value
-pub fn tag_value_new(f: &IfdEntry) -> (TagValue, String)
+/// Convert a IfdEntry into a tuple of TagValue
+pub fn tag_value_new(f: &IfdEntry) -> TagValue
 {
 	match f.format {
 		IfdFormat::Ascii => {
@@ -38,117 +38,95 @@ pub fn tag_value_new(f: &IfdEntry) -> (TagValue, String)
 			// In theory it should be pure ASCII but we admit UTF-8
 			let s = String::from_utf8_lossy(&f.data[0..tot]);
 			let s = s.into_owned();
-			(TagValue::Ascii(s.to_string()), s.to_string())
+			TagValue::Ascii(s.to_string())
 		},
 		IfdFormat::U16 => {
 			if f.data.len() < (f.count as usize * 2) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_u16_array(f.le, f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::U16(a), b)
+			TagValue::U16(a)
 		},
 		IfdFormat::I16 => {
 			if f.data.len() < (f.count as usize * 2) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_i16_array(f.le, f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::I16(a), b)
+			TagValue::I16(a)
 		},
 		IfdFormat::U8 => {
 			if f.data.len() < (f.count as usize * 1) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = f.data.clone();
-			let b = numarray_to_string(&a);
-			(TagValue::U8(a), b)
+			TagValue::U8(a)
 		},
 		IfdFormat::I8 => {
 			if f.data.len() < (f.count as usize * 1) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_i8_array(f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::I8(a), b)
+			TagValue::I8(a)
 		},
 		IfdFormat::U32 => {
 			if f.data.len() < (f.count as usize * 4) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_u32_array(f.le, f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::U32(a), b)
+			TagValue::U32(a)
 		},
 		IfdFormat::I32 => {
 			if f.data.len() < (f.count as usize * 4) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_i32_array(f.le, f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::I32(a), b)
+			TagValue::I32(a)
 		},
 		IfdFormat::F32 => {
 			if f.data.len() < (f.count as usize * 4) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_f32_array(f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::F32(a), b)
+			TagValue::F32(a)
 		},
 		IfdFormat::F64 => {
 			if f.data.len() < (f.count as usize * 8) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_f64_array(f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::F64(a), b)
+			TagValue::F64(a)
 		},
 		IfdFormat::URational => {
 			if f.data.len() < (f.count as usize * 8) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_urational_array(f.le, f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::URational(a), b)
+			TagValue::URational(a)
 		},
 		IfdFormat::IRational => {
 			if f.data.len() < (f.count as usize * 8) {
-				return (TagValue::Invalid(f.data.clone(), f.le,
-							f.format as u16, f.count),
-					"Invalid".to_string());
+				return TagValue::Invalid(f.data.clone(), f.le,
+							             f.format as u16, f.count);
 			}
 			let a = read_irational_array(f.le, f.count, &f.data[..]);
-			let b = numarray_to_string(&a);
-			(TagValue::IRational(a), b)
+			TagValue::IRational(a)
 		},
 
 		IfdFormat::Undefined => {
 			let a = f.data.clone();
-			let b = numarray_to_string(&a);
-			(TagValue::Undefined(a, f.le), b)
+			TagValue::Undefined(a, f.le)
 		},
 
-		_ => (TagValue::Unknown(f.data.clone(), f.le),
-					"<unknown blob>".to_string()),
+		_ => TagValue::Unknown(f.data.clone(), f.le)
 	}
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,3 +1,5 @@
+use types::ExifError;
+
 /// Detect the type of an image contained in a byte buffer
 pub fn detect_type(contents: &Vec<u8>) -> &str
 {
@@ -34,37 +36,30 @@ pub fn detect_type(contents: &Vec<u8>) -> &str
 }
 
 /// Find the embedded TIFF in a JPEG image (that in turn contains the EXIF data)
-pub fn find_embedded_tiff_in_jpeg(contents: &Vec<u8>) -> (usize, usize, String)
+pub fn find_embedded_tiff_in_jpeg(contents: &Vec<u8>)
+                                  -> Result<(usize, usize), ExifError>
 {
-	let mut err = "Scan past EOF and no EXIF found".to_string();
-	
-	{
 	let mut offset = 2 as usize;
-	let mut size: usize;
 
 	while offset < contents.len() {
 		if contents.len() < (offset + 4) {
-			err = "JPEG truncated in marker header".to_string();
-			break;
+			return Err(ExifError::JpegWithoutExif("JPEG truncated in marker header".to_string()))
 		}
 
 		let marker: u16 = (contents[offset] as u16) * 256 + (contents[offset + 1] as u16);
 
 		if marker < 0xff00 {
-			err = format!("Invalid marker {:x}", marker);
-			break;
+			return Err(ExifError::JpegWithoutExif(format!("Invalid marker {:x}", marker)))
 		}
 
 		offset += 2;
-		size = (contents[offset] as usize) * 256 + (contents[offset + 1] as usize);
+		let mut size = (contents[offset] as usize) * 256 + (contents[offset + 1] as usize);
 
 		if size < 2 {
-			err = "JPEG marker size must be at least 2 (because of the size word)".to_string();
-			break;
+			return Err(ExifError::JpegWithoutExif("JPEG marker size must be at least 2 (because of the size word)".to_string()))
 		}
 		if contents.len() < (offset + size) {
-			err = "JPEG truncated in marker body".to_string();
-			break;
+			return Err(ExifError::JpegWithoutExif("JPEG truncated in marker body".to_string()))
 		}
 
 		if marker == 0xffe1 {
@@ -73,8 +68,7 @@ pub fn find_embedded_tiff_in_jpeg(contents: &Vec<u8>) -> (usize, usize, String)
 			size -= 2;
 
 			if size < 6 {
-				err = "EXIF preamble truncated".to_string();
-				break;
+				return Err(ExifError::JpegWithoutExif("EXIF preamble truncated".to_string()))
 			}
 
 			if contents[offset + 0] != ('E' as u8) &&
@@ -83,25 +77,21 @@ pub fn find_embedded_tiff_in_jpeg(contents: &Vec<u8>) -> (usize, usize, String)
 					contents[offset + 3] != ('f' as u8) &&
 					contents[offset + 4] != 0 &&
 					contents[offset + 5] != 0 {
-				err = "EXIF preamble unrecognized".to_string();
-				break;
+				return Err(ExifError::JpegWithoutExif("EXIF preamble unrecognized".to_string()))
 			}
 
 			// Discard the 'Exif\0\0' preamble
 			offset += 6;
 			size -= 6;
 
-			return (offset, size, "".to_string());
+			return Ok((offset, size));
 		}
 		if marker == 0xffda {
 			// last marker
-			err = "Last mark found and no EXIF".to_string();
-			break;
+			return Err(ExifError::JpegWithoutExif("Last mark found and no EXIF".to_string()))
 		}
-
 		offset += size;
 	}
-	}
 
-	return (0, 0, err);
+	return Err(ExifError::JpegWithoutExif("Scan past EOF and no EXIF found".to_string()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //!		for entry in &exif.entries {
 //!			println!("	{}: {}",
-//!					entry.tag_readable, 
+//!					entry.tag,
 //!					entry.value_more_readable);
 //!		}
 //!	},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::process;
 use std::io::Write;
-use std::error::Error;
 extern crate rexif;
 
 use rexif::ExifTag;
@@ -34,8 +33,7 @@ fn main()
 				}
 			},
 			Err(e) => {
-				writeln!(std::io::stderr(), "Error in {}: {} {}", &arg,
-					Error::description(&e), e.extra).unwrap();
+				writeln!(std::io::stderr(), "Error in {}: {}", &arg, e).unwrap();
 			}
 	 	}
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main()
 						*/
 					} else {
 						println!("	{}: {}",
-								entry.tag_readable, 
+								entry.tag,
 								entry.value_more_readable);
 					}
 				}

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -13,16 +13,15 @@ type InExifResult = Result<(), ExifError>;
 /// but the raw information of tag is still available in the ifd member.
 pub fn parse_exif_entry(f: &IfdEntry) -> ExifEntry
 {
-	let (value, readable_value) = tag_value_new(f);
+	let value = tag_value_new(f);
 
 	let mut e = ExifEntry {
 			namespace: f.namespace,
 			ifd: f.clone(),
 			tag: ExifTag::UnknownToMe,
-			value: value,
+			value: value.clone(),
 			unit: "Unknown".to_string(),
-			value_readable: readable_value.clone(),
-			value_more_readable: readable_value.clone(),
+			value_more_readable: format!("{}", value),
 			};
 
 	let (tag, unit, format, min_count, max_count, more_readable) = tag_to_exif(f.tag);
@@ -45,23 +44,23 @@ pub fn parse_exif_entry(f: &IfdEntry) -> ExifEntry
 	}
 
 	if format != f.format {
-		warning(&format!("EXIF tag {:x} {}, expected format {}, found {}",
-			f.tag, f.tag, format as u8, f.format as u8));
+		warning(&format!("EXIF tag {:x} {} ({}), expected format {} ({:?}), found {} ({:?})",
+			f.tag, f.tag, tag, format as u8, format, f.format as u8, f.format));
 		return e;
 	}
 
 	if min_count != -1 &&
 			((f.count as i32) < min_count ||
 			(f.count as i32) > max_count) {
-		warning(&format!("EXIF tag {:x} {}, format {}, expected count {}..{} found {}",
-			f.tag, f.tag, format as u8, min_count,
+		warning(&format!("EXIF tag {:x} {} ({:?}), format {}, expected count {}..{} found {}",
+			f.tag, f.tag, tag, format as u8, min_count,
 			max_count, f.count));
 		return e;
 	}
 
 	e.tag = tag;
 	e.unit = unit.to_string();
-	e.value_more_readable = more_readable(&e.value, &readable_value);
+	e.value_more_readable = more_readable(&e.value);
 
 	return e;
 }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -21,12 +21,11 @@ pub fn parse_exif_entry(f: &IfdEntry) -> ExifEntry
 			tag: ExifTag::UnknownToMe,
 			value: value,
 			unit: "Unknown".to_string(),
-			tag_readable: format!("Unparsed tag {:x}", f.tag).to_string(),
 			value_readable: readable_value.clone(),
 			value_more_readable: readable_value.clone(),
 			};
 
-	let (tag, tag_readable, unit, format, min_count, max_count, more_readable) = tag_to_exif(f.tag);
+	let (tag, unit, format, min_count, max_count, more_readable) = tag_to_exif(f.tag);
 
 	if tag == ExifTag::UnknownToMe {
 		// Unknown EXIF tag type
@@ -47,7 +46,7 @@ pub fn parse_exif_entry(f: &IfdEntry) -> ExifEntry
 
 	if format != f.format {
 		warning(&format!("EXIF tag {:x} {}, expected format {}, found {}",
-			f.tag, tag_readable, format as u8, f.format as u8));
+			f.tag, f.tag, format as u8, f.format as u8));
 		return e;
 	}
 
@@ -55,13 +54,12 @@ pub fn parse_exif_entry(f: &IfdEntry) -> ExifEntry
 			((f.count as i32) < min_count ||
 			(f.count as i32) > max_count) {
 		warning(&format!("EXIF tag {:x} {}, format {}, expected count {}..{} found {}",
-			f.tag, tag_readable, format as u8, min_count,
+			f.tag, f.tag, format as u8, min_count,
 			max_count, f.count));
 		return e;
 	}
 
 	e.tag = tag;
-	e.tag_readable = tag_readable.to_string();
 	e.unit = unit.to_string();
 	e.value_more_readable = more_readable(&e.value, &readable_value);
 

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -106,9 +106,7 @@ fn parse_exif_ifd(le: bool, contents: &[u8], ioffset: usize,
 
 	// println!("Offset is {}", offset);
 	if contents.len() < (offset + 2) {
-		return Err(ExifError{
-			kind: ExifErrorKind::ExifIfdTruncated,
-			extra: "Truncated at dir entry count".to_string()});
+		return Err(ExifError::ExifIfdTruncated("Truncated at dir entry count".to_string()))
 	}
 
 	let count = read_u16(le, &contents[offset..offset + 2]);
@@ -117,9 +115,7 @@ fn parse_exif_ifd(le: bool, contents: &[u8], ioffset: usize,
 	offset += 2;
 
 	if contents.len() < (offset + ifd_length) {
-		return Err(ExifError{
-			kind: ExifErrorKind::ExifIfdTruncated,
-			extra: "Truncated at dir listing".to_string()});
+		return Err(ExifError::ExifIfdTruncated("Truncated at dir listing".to_string()));
 	}
 
 	let (mut ifd, _) = parse_ifd(true, le, count, &contents[offset..offset + ifd_length]);
@@ -167,9 +163,7 @@ pub fn parse_ifds(le: bool, ifd0_offset: usize, contents: &[u8]) -> ExifEntryRes
 		let exif_offset = entry.data_as_offset();
 
 		if contents.len() < exif_offset {
-			return Err(ExifError{
-				kind: ExifErrorKind::ExifIfdTruncated,
-				extra: "Exif SubIFD goes past EOF".to_string()});
+			return Err(ExifError::ExifIfdTruncated("Exif SubIFD goes past EOF".to_string()));
 		}
 
 		match parse_exif_ifd(le, &contents, exif_offset, &mut exif_entries) {
@@ -195,9 +189,7 @@ pub fn parse_tiff(contents: &[u8]) -> ExifEntryResult
 	let mut le = false;
 
 	if contents.len() < 8 {
-		return Err(ExifError{
-			kind: ExifErrorKind::TiffTruncated,
-			extra: "".to_string()});
+		return Err(ExifError::TiffTruncated);
 	} else if contents[0] == ('I' as u8) &&
 			contents[1] == ('I' as u8) &&
 			contents[2] == 42 && contents[3] == 0 {
@@ -210,9 +202,7 @@ pub fn parse_tiff(contents: &[u8]) -> ExifEntryResult
 		let err = format!("Preamble is {:x} {:x} {:x} {:x}",
 			contents[0], contents[1],
 			contents[2], contents[3]);
-		return Err(ExifError{
-			kind: ExifErrorKind::TiffBadPreamble,
-			extra: err.to_string()});
+		return Err(ExifError::TiffBadPreamble(err.to_string()));
 	}
 
 	let offset = read_u32(le, &contents[4..8]) as usize;

--- a/src/types.rs
+++ b/src/types.rs
@@ -336,10 +336,6 @@ pub struct ExifEntry {
 	/// `value_more_readable` contains a single string with all three parts
 	/// combined.
 	pub unit: String,
-	/// Human-readable, but simple, version of `value`.
-	/// Enumerations or tuples are not interpreted nor combined. This member contains a
-	/// correct data representation even if tag is `UnknownToMe`.
-	pub value_readable: String,
 	/// Human-readable and "pretty" version of `value`.
 	/// Enumerations and tuples are interpreted and combined. If `value`
 	/// has a unit, it is also added. 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use super::rational::*;
+use std::fmt;
 use std::result::Result;
 
 /// Top-level structure that contains all parsed metadata inside an image
@@ -191,6 +192,113 @@ pub enum ExifTag {
 	GPSDifferential = 0x00001e,
 }
 
+impl fmt::Display for ExifTag {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "{}", match *self {
+			ExifTag::ImageDescription => "Image Description",
+			ExifTag::Make => "Manufacturer",
+			ExifTag::HostComputer => "Host computer",
+			ExifTag::Model => "Model",
+			ExifTag::Orientation => "Orientation",
+			ExifTag::XResolution => "X Resolution",
+			ExifTag::YResolution => "Y Resolution",
+			ExifTag::ResolutionUnit => "Resolution Unit",
+			ExifTag::Software => "Software",
+			ExifTag::DateTime => "Image date",
+			ExifTag::WhitePoint => "White Point",
+			ExifTag::PrimaryChromaticities => "Primary Chromaticities",
+			ExifTag::YCbCrCoefficients => "YCbCr Coefficients",
+			ExifTag::ReferenceBlackWhite => "Reference Black/White",
+			ExifTag::Copyright => "Copyright",
+			ExifTag::ExifOffset => "This image has an Exif SubIFD",
+			ExifTag::GPSOffset => "This image has a GPS SubIFD",
+			ExifTag::ExposureTime => "Exposure time",
+			ExifTag::FNumber => "Aperture",
+			ExifTag::ExposureProgram => "Exposure program",
+			ExifTag::SpectralSensitivity => "Spectral sensitivity",
+			ExifTag::ISOSpeedRatings => "ISO speed ratings",
+			ExifTag::OECF => "OECF",
+			ExifTag::ExifVersion => "Exif version",
+			ExifTag::DateTimeOriginal => "Date of original image",
+			ExifTag::DateTimeDigitized => "Date of image digitalization",
+			ExifTag::ShutterSpeedValue => "Shutter speed",
+			ExifTag::ApertureValue => "Aperture value",
+			ExifTag::BrightnessValue => "Brightness value",
+			ExifTag::ExposureBiasValue => "Exposure bias value",
+			ExifTag::MaxApertureValue => "Maximum aperture value",
+			ExifTag::SubjectDistance => "Subject distance",
+			ExifTag::MeteringMode => "Meteting mode",
+			ExifTag::LightSource => "Light source",
+			ExifTag::Flash => "Flash",
+			ExifTag::FocalLength => "Focal length",
+			ExifTag::SubjectArea => "Subject area",
+			ExifTag::MakerNote => "Maker note",
+			ExifTag::UserComment => "User comment",
+			ExifTag::FlashPixVersion => "Flashpix version",
+			ExifTag::ColorSpace => "Color space",
+			ExifTag::FlashEnergy => "Flash energy",
+			ExifTag::RelatedSoundFile => "Related sound file",
+			ExifTag::FocalPlaneXResolution => "Focal plane X resolution",
+			ExifTag::FocalPlaneYResolution => "Focal plane Y resolution",
+			ExifTag::FocalPlaneResolutionUnit => "Focal plane resolution unit",
+			ExifTag::SubjectLocation => "Subject location",
+			ExifTag::ExposureIndex => "Exposure index",
+			ExifTag::SensingMethod => "Sensing method",
+			ExifTag::FileSource => "File source",
+			ExifTag::SceneType => "Scene type",
+			ExifTag::CFAPattern => "CFA Pattern",
+			ExifTag::CustomRendered => "Custom rendered",
+			ExifTag::ExposureMode => "Exposure mode",
+			ExifTag::WhiteBalanceMode => "White balance mode",
+			ExifTag::DigitalZoomRatio => "Digital zoom ratio",
+			ExifTag::FocalLengthIn35mmFilm => "Equivalent focal length in 35mm",
+			ExifTag::SceneCaptureType => "Scene capture type",
+			ExifTag::GainControl => "Gain control",
+			ExifTag::Contrast => "Contrast",
+			ExifTag::Saturation => "Saturation",
+			ExifTag::Sharpness => "Sharpness",
+			ExifTag::LensSpecification => "Lens specification",
+			ExifTag::LensMake => "Lens manufacturer",
+			ExifTag::LensModel => "Lens model",
+			ExifTag::DeviceSettingDescription => "Device setting description",
+			ExifTag::SubjectDistanceRange => "Subject distance range",
+			ExifTag::ImageUniqueID => "Image unique ID",
+			ExifTag::GPSVersionID => "GPS version ID",
+			ExifTag::GPSLatitudeRef => "GPS latitude ref",
+			ExifTag::GPSLatitude => "GPS latitude",
+			ExifTag::GPSLongitudeRef => "GPS longitude ref",
+			ExifTag::GPSLongitude => "GPS longitude",
+			ExifTag::GPSAltitudeRef => "GPS altitude ref",
+			ExifTag::GPSAltitude => "GPS altitude",
+			ExifTag::GPSTimeStamp => "GPS timestamp",
+			ExifTag::GPSSatellites => "GPS satellites",
+			ExifTag::GPSStatus => "GPS status",
+			ExifTag::GPSMeasureMode => "GPS measure mode",
+			ExifTag::GPSDOP => "GPS Data Degree of Precision (DOP)",
+			ExifTag::GPSSpeedRef => "GPS speed ref",
+			ExifTag::GPSSpeed => "GPS speed",
+			ExifTag::GPSTrackRef => "GPS track ref",
+			ExifTag::GPSTrack => "GPS track",
+			ExifTag::GPSImgDirectionRef => "GPS image direction ref",
+			ExifTag::GPSImgDirection => "GPS image direction",
+			ExifTag::GPSMapDatum => "GPS map datum",
+			ExifTag::GPSDestLatitudeRef => "GPS destination latitude ref",
+			ExifTag::GPSDestLatitude => "GPS destination latitude",
+			ExifTag::GPSDestLongitudeRef => "GPS destination longitude ref",
+			ExifTag::GPSDestLongitude => "GPS destination longitude",
+			ExifTag::GPSDestBearingRef => "GPS destination bearing ref",
+			ExifTag::GPSDestBearing => "GPS destination bearing",
+			ExifTag::GPSDestDistanceRef => "GPS destination distance ref",
+			ExifTag::GPSDestDistance => "GPS destination distance",
+			ExifTag::GPSProcessingMethod => "GPS processing method",
+			ExifTag::GPSAreaInformation => "GPS area information",
+			ExifTag::GPSDateStamp => "GPS date stamp",
+			ExifTag::GPSDifferential => "GPS differential",
+			ExifTag::UnknownToMe => "Unknown to this library, or manufacturer-specific",
+		})
+	}
+}
+
 /// Enumeration that represents the possible data formats of an IFD entry.
 ///
 /// Any enumeration item can be cast to u16 to get the low-level format code
@@ -237,8 +345,6 @@ pub struct ExifEntry {
 	/// `value_more_readable` contains a single string with all three parts
 	/// combined.
 	pub unit: String,
-	/// Human-readable name of the `tag`, for debugging and listing purposes
-	pub tag_readable: String,
 	/// Human-readable, but simple, version of `value`.
 	/// Enumerations or tuples are not interpreted nor combined. This member contains a
 	/// correct data representation even if tag is `UnknownToMe`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use super::rational::*;
 use std::fmt;
 use std::result::Result;
+use std::io;
 
 /// Top-level structure that contains all parsed metadata inside an image
 #[derive(Debug)]
@@ -12,26 +13,16 @@ pub struct ExifData {
 }
 
 /// Possible fatal errors that may happen when an image is parsed.
-#[derive(Copy, Clone)]
-pub enum ExifErrorKind {
-	FileOpenError,
-	FileSeekError,
-	FileReadError,
+#[derive(Debug)]
+pub enum ExifError {
+	IoError(io::Error),
 	FileTypeUnknown,
-	JpegWithoutExif,
+	JpegWithoutExif(String),
 	TiffTruncated,
-	TiffBadPreamble,
+	TiffBadPreamble(String),
 	IfdTruncated,
-	ExifIfdTruncated,
+	ExifIfdTruncated(String),
 	ExifIfdEntryNotFound,
-}
-
-/// EXIF parsing error type
-pub struct ExifError {
-	/// The general kind of the error that aborted the parsing
-	pub kind: ExifErrorKind,
-	/// Extra context info about the error, when available
-	pub extra: String
 }
 
 /// Structure that represents a parsed IFD entry of a TIFF image

--- a/src/types_impl.rs
+++ b/src/types_impl.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::io;
 use super::types::*;
 use super::lowlevel::*;
+use super::ifdformat::numarray_to_string;
 
 /// Convert an IFD format code to the IfdFormat enumeration
 pub fn ifdformat_new(n: u16) -> IfdFormat
@@ -130,4 +131,25 @@ impl From<io::Error> for ExifError {
     fn from(err: io::Error) -> ExifError {
         ExifError::IoError(err)
     }
+}
+
+impl fmt::Display for TagValue {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			TagValue::Ascii(ref s) => write!(f, "{}", s),
+			TagValue::U16(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::I16(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::U8(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::I8(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::U32(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::I32(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::F32(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::F64(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::URational(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::IRational(ref a) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::Undefined(ref a, _) => write!(f, "{}", numarray_to_string(a)),
+			TagValue::Unknown(ref _a, _) => write!(f, "<unknown blob>"),
+			TagValue::Invalid(ref _data, _le, _fmt, _cnt) => write!(f, "Invalid"),
+		}
+	}
 }


### PR DESCRIPTION
I'm sorry for this being a rather huge pull request.  At least it is split into four commits.

The changes are mainly to get rid of `tag_readable` and `value_readable` in `ExifEntry`, and to replace them with implementing the Display trait of `ExifTag` and `ExifValue` (I would like to get rid of value_more_readable as well, but replacing that is more complicated).

Also, `ExifError` is changed from beeing an enum plus a string to being an enum where some variants contain extra information.
