### PR TITLE
Allow Path arguments to parse_file.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 
 use std::fs::File;
 use std::io::{Seek,SeekFrom,Read};
+use std::path::Path;
 
 mod lowlevel;
 mod rational;
@@ -93,7 +94,7 @@ pub fn read_file(f: &mut File) -> ExifResult
 }
 
 /// Opens an image (passed as a file name), tries to read and parse it.
-pub fn parse_file(fname: &str) -> ExifResult
+pub fn parse_file<P: AsRef<Path>>(fname: P) -> ExifResult
 {
 	read_file(&mut try!(File::open(fname)))
 }


### PR DESCRIPTION
Improve interoperability with other rust libraries by allowing `parse_file()` to take a `Path` ref as a parameter.  By using `AsRef`, it is still possible to use a `&str`.